### PR TITLE
avoid bounds out of range because of length == 0.

### DIFF
--- a/hci.go
+++ b/hci.go
@@ -234,7 +234,7 @@ func parseEIR(eir []byte) (gatt.Advertisement, error) {
 			break
 		}
 		length := int(eir[i])
-		if i+2+length > len(eir) {
+		if i+2+length > len(eir) || length <= 0 {
 			break
 		}
 		t := eir[i+1]


### PR DESCRIPTION
avoid to occur slice bounds out of range because of length == 0.
